### PR TITLE
Fix items disapear by local  search

### DIFF
--- a/src/async-paginate.jsx
+++ b/src/async-paginate.jsx
@@ -10,6 +10,7 @@ import wrapMenuList from './wrap-menu-list';
 
 export const MenuList = wrapMenuList(defaultComponents.MenuList);
 
+const alwaysTrue () => true;
 const sleep = (ms) => new Promise((resolve) => {
   setTimeout(() => {
     resolve();
@@ -279,6 +280,7 @@ class AsyncPaginate extends Component {
         isLoading={currentOptions.isLoading}
         isFirstLoad={currentOptions.isFirstLoad}
         options={currentOptions.options}
+        filterOption={alwaysTrue}
         components={{
           MenuList,
           ...components,


### PR DESCRIPTION
local search would also randomly remove items. I fixed it by always making it show all items (effectivly disabling local search)