### PR TITLE
Fix cache infinite loading issue with debounce [bug fix]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-select-async-paginate",
+  "name": "@braden-m/react-select-async-paginate",
   "version": "0.2.8",
   "description": "Wrapper above react-select that supports pagination on menu scroll",
   "main": "lib/index.js",

--- a/src/async-paginate.jsx
+++ b/src/async-paginate.jsx
@@ -167,16 +167,23 @@ class AsyncPaginate extends Component {
       return;
     }
 
-    await this.setState((prevState) => ({
-      search,
-      optionsCache: {
-        ...prevState.optionsCache,
-        [search]: {
-          ...currentOptions,
-          isLoading: true,
+    await this.setState((prevState) => {
+      const prevSearches = Object.keys(prevState.optionsCache);
+      const prevOptionsCache = prevState.optionsCache;
+      prevSearches.forEach((ps) => {
+        prevOptionsCache[ps].isLoading = false;
+      });
+      return {
+        search,
+        optionsCache: {
+          ...prevState.optionsCache,
+          [search]: {
+            ...currentOptions,
+            isLoading: true,
+          },
         },
-      },
-    }));
+      };
+    });
 
     const {
       debounceTimeout,


### PR DESCRIPTION
There is currently an issue when `debounceTimeout` is set where some searches will appear to "load" forever (i.e. display the loading icon), but not actually perform a search.

You can test the issue yourself with the simple debounce example: https://codesandbox.io/s/5y2xq39v5k

You're not able to view the state of `AsyncPaginate` (I suppose since `codesandbox.io` is using an iframe?). However, you can repeat the bug by following these steps:
1) On a fresh reload (i.e. without searching previously), type "option" quickly into the select box.
2) Wait until the search results return.
3) Clear the select box, then type in any of "o", "op", "opt", "opti", or "optio" - that is, any search term that is typed in the process of typing "option", but does not have time to actually perform the search due to debounce.

The "search" for these terms will seem to go on infinitely, and never return any results.

---


This is due to the `optionsCache` state variable on `AsyncPaginate` being filled with the search options as they are typed. This PR moves setting the cache until after the debounce timeout, so that queries which do not run are not cached.