### PR TITLE
Load options when cacheUniq changes and defaultOptions: true

### DIFF
--- a/packages/react-select-async-paginate/src/__tests__/async-paginate-base-test.jsx
+++ b/packages/react-select-async-paginate/src/__tests__/async-paginate-base-test.jsx
@@ -211,6 +211,36 @@ test('should load options on mount if "defaultOptions" is true', async () => {
   expect(loadOptionsMethod.mock.calls.length).toBe(1);
 });
 
+test('should load options on cacheUniq change if "defaultOptions" is true', async () => {
+  const page = setup({
+    defaultOptions: true,
+    cacheUniq: 1,
+  });
+
+  await page.componentDidMount();
+
+  await page.setProps({
+    cacheUniq: 2,
+  });
+
+  // the expected count is 2: one for initial mount, one for cacheUniq change
+  expect(loadOptionsMethod.mock.calls.length).toBe(2);
+});
+
+test('should not load options on cacheUniq change if "defaultOptions" is not true', async () => {
+  const page = setup({
+    cacheUniq: 1,
+  });
+
+  await page.componentDidMount();
+
+  await page.setProps({
+    cacheUniq: 2,
+  });
+
+  expect(loadOptionsMethod.mock.calls.length).toBe(0);
+});
+
 test('should redefine additional in initial options cache', () => {
   const options = [
     {

--- a/packages/react-select-async-paginate/src/async-paginate-base.jsx
+++ b/packages/react-select-async-paginate/src/async-paginate-base.jsx
@@ -105,9 +105,10 @@ class AsyncPaginateBase extends Component {
     }
   }
 
-  componentDidUpdate(oldProps) {
+  async componentDidUpdate(oldProps) {
     const {
       cacheUniq,
+      defaultOptions,
       inputValue,
       menuIsOpen,
     } = this.props;
@@ -116,6 +117,9 @@ class AsyncPaginateBase extends Component {
       this.setState({
         optionsCache: {},
       });
+      if (defaultOptions === true) {
+        await this.loadOptions();
+      }
     } else {
       if (inputValue !== oldProps.inputValue) {
         this.handleInputChange(inputValue);


### PR DESCRIPTION
This ensures a more consistent behaviour with defaultOptions: true and cacheUniq set.
When cacheUniq changes and defaultOptions === true, new options are automatically loaded.
This is consistent with how the defaultOptions == true behaves on initial render.

Fixes #33 