### PR TITLE
Add missing await for setState in componentDidUpdate

### DIFF
--- a/packages/react-select-async-paginate/src/async-paginate-base.jsx
+++ b/packages/react-select-async-paginate/src/async-paginate-base.jsx
@@ -114,7 +114,7 @@ class AsyncPaginateBase extends Component {
     } = this.props;
 
     if (oldProps.cacheUniq !== cacheUniq) {
-      this.setState({
+      await this.setState({
         optionsCache: {},
       });
       if (defaultOptions === true) {


### PR DESCRIPTION
There was no await on the `setState` in `componentDidUpdate`.
It meant the `loadOptions` got the old cache values.
This was breaking pagination, because `loadOptions` received non-empty options.