### PR TITLE
fix: set selectRef default prop to null to avoid warnings about refs …

### DIFF
--- a/packages/react-select-async-paginate/src/async-paginate-base.jsx
+++ b/packages/react-select-async-paginate/src/async-paginate-base.jsx
@@ -61,7 +61,7 @@ class AsyncPaginateBase extends Component {
 
     cacheUniq: null,
 
-    selectRef: Function.prototype,
+    selectRef: null,
   };
 
   constructor(props) {


### PR DESCRIPTION
…not available when wrapping in a functional component

Solves #36