### PR TITLE
Remove unnecessary @babel/runtime dependency

### DIFF
--- a/packages/react-select-async-paginate/package.json
+++ b/packages/react-select-async-paginate/package.json
@@ -38,7 +38,6 @@
     "react-select": "^2.0.0 || ^3.0.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.5",
     "@seznam/compose-react-refs": "^1.0.5",
     "react-is-mounted-hook": "^1.0.3",
     "sleep-promise": "^9.0.0"

--- a/packages/react-select-fetch/package.json
+++ b/packages/react-select-fetch/package.json
@@ -40,7 +40,6 @@
     "react-select-async-paginate": "^0.4.0 || ^0.5.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.12.5",
     "qs": "^6.9.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I found that removing `@babel/runtime` dependency does not cause any issues but it would eventually fix the issue I reported here: https://github.com/vtaits/react-select-async-paginate/issues/74