### PR TITLE
[react-select-fetch] version 0.3.2

### DIFF
--- a/packages/react-select-fetch/package.json
+++ b/packages/react-select-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-select-fetch",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Wrapper above react-select-async-paginate that loads options from specified url",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
This PR bumps `react-select-fetch` version to publish on NPM and allow installing it with `react-select` v4.

@vtaits Please add changelog entry on the day you are merging this.