### PR TITLE
Don't use debounceTimeout on opening dropdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
   },
   "eslint.nodePath": ".yarn/sdks",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#0B276F",
+    "titleBar.activeBackground": "#10379C",
+    "titleBar.activeForeground": "#FCFCFF"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,4 @@
   "eslint.nodePath": ".yarn/sdks",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#0B276F",
-    "titleBar.activeBackground": "#10379C",
-    "titleBar.activeForeground": "#FCFCFF"
-  }
 }

--- a/.yarn/sdks/typescript/package.json
+++ b/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "4.3.5-sdk",
+  "version": "4.4.3-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs"
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "private": true,
-  "workspaces": [
-    "packages/react-select-async-paginate",
-    "packages/react-select-fetch"
-  ],
+  "workspaces": [ "packages/*" ],
   "repository": "git@github.com:vtaits/react-select-async-paginate.git",
   "author": "Vadim Taits",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/react-select-async-paginate",
+    "packages/react-select-fetch"
   ],
   "repository": "git@github.com:vtaits/react-select-async-paginate.git",
   "author": "Vadim Taits",

--- a/packages/react-select-async-paginate/__stories__/Debounce.tsx
+++ b/packages/react-select-async-paginate/__stories__/Debounce.tsx
@@ -28,7 +28,7 @@ OptionType,
 GroupBase<OptionType>,
 null
 > = async (search, prevOptions) => {
-  await sleep(1000);
+  await sleep(200);
 
   let filteredOptions;
   if (!search) {
@@ -82,7 +82,7 @@ const Example: FC = () => {
       </p>
 
       <AsyncPaginate
-        debounceTimeout={300}
+        debounceTimeout={3000}
         value={value}
         loadOptions={wrappedLoadOptions}
         onChange={onChange}

--- a/packages/react-select-async-paginate/src/useAsyncPaginateBase.ts
+++ b/packages/react-select-async-paginate/src/useAsyncPaginateBase.ts
@@ -124,7 +124,7 @@ export const requestOptions = async <OptionType, Group extends GroupBase<OptionT
     },
   }));
 
-  if (debounceTimeout > 0) {
+  if (debounceTimeout > 0 && currentInputValue !== '') {
     await sleepParam(debounceTimeout);
 
     const newInputValue = paramsRef.current.inputValue;


### PR DESCRIPTION
Hi!

this PR targets the behavior of react-select-asnc-paginate when you make use of the "debounceTimeout" Attribut with higher values than a normal async fetch options request take time to complete.

For example you configured 1sec as a debounceTimeout but the fetch options call only took around ~150ms, open the dropdown will take 1sec. This effect gets more visible if you chose higher debounceTimeout Values but even with 1sec it is noticeable and so it feels some kind of slow. You can easily test it on master branch with the Debounce-Story, just remove the artificial wait on the response and raise the debounceTimeout Value.

What did the trick was to check if the user typed something in addition to the check if debounceTimeout is 0.

Greetings,
Daniel