### PR TITLE
feat: make wrapMenuList generic

### DIFF
--- a/packages/react-select-async-paginate/src/wrapMenuList.tsx
+++ b/packages/react-select-async-paginate/src/wrapMenuList.tsx
@@ -25,21 +25,21 @@ export type BaseSelectProps = {
   shouldLoadMore: ShouldLoadMore;
 };
 
-type MenuListType = <
+type MenuListType <
 Option = unknown,
 IsMulti extends boolean = boolean,
 Group extends GroupBase<Option> = GroupBase<Option>,
->(props: MenuListProps<Option, IsMulti, Group>) => ReactElement;
+> = (props: MenuListProps<Option, IsMulti, Group>) => ReactElement;
 
-export function wrapMenuList(
+export function wrapMenuList<
+Option = unknown,
+IsMulti extends boolean = boolean,
+Group extends GroupBase<Option> = GroupBase<Option>,
+>(
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  MenuList: MenuListType,
+  MenuList: MenuListType<Option, IsMulti, Group>,
 ) {
-  function WrappedMenuList<
-    OptionType = unknown,
-    IsMulti extends boolean = boolean,
-    Group extends GroupBase<OptionType> = GroupBase<OptionType>,
-  >(props: MenuListProps<OptionType, IsMulti, Group>) {
+  function WrappedMenuList(props: MenuListProps<Option, IsMulti, Group>) {
     const {
       selectProps,
       innerRef,


### PR DESCRIPTION
This makes the `wrapMenuList` function generic.

Currently wrapping custom components with `wrapMenuList` is quite difficult in TypeScript, as it almost always requires type casting. It neither accepts a generic MenuList component, nor returns one that is suitable for `SelectComponentsConfig`. This is evident from the code in this repository, too, as the returned components object needed a type cast before. 

By making the function generic and return a generic component, no type casts are necessary on the outside. There are still some required here internally in two places:
- the `innerRef` prop signature does not match with what react-select itself uses, but this should be fine, as React really allows both signatures.
- in tests, the props object is not a full props object, now that it extends `MenuListProps`, but for testing purposes it should not matter either.