### PR TITLE
Add Yarn 4.3.1 as the package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "validate": "yarn build && yarn lint && yarn test:ts && yarn test:unit:cov",
     "codecov": "yarn workspaces foreach --all run codecov"
   },
+  "packageManager": "yarn@4.3.1",
   "devDependencies": {
     "@storybook/addon-essentials": "^8.0.6",
     "@storybook/addon-interactions": "^8.0.6",


### PR DESCRIPTION
This PR updates the package manager in package.json to Yarn 4.3.1. This change addresses compatibility issues with older versions of Yarn.